### PR TITLE
Delay update, mutate, create and change emits until batch set is complete

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -398,8 +398,6 @@
                     setAttribute.call(this, util.makeUuid(), value);
                 }, this);
                 if(!isEmpty(updatedAttributes)) {
-                    this.emit('change:multiple', updatedAttributes);
-
                     for(var key in updatedAttributes) {
                         emitAttributeEvents.call(this, key);
                     }
@@ -436,8 +434,6 @@
                     setAttribute.call(this, key, value);
                 }, this);
                 if(!isEmpty(updatedAttributes)) {
-                    this.emit('change:multiple', updatedAttributes);
-
                     for(var key in updatedAttributes) {
                         emitAttributeEvents.call(this, key);
                     }


### PR DESCRIPTION
This may be a matter of opinion, but when I call module.set({foo: 'bar', hello: 'world'}), I would expect all the attributes to get set before firing the 'change:foo' event. Otherwise if my handler for that event depends on hello, the object will be in a weird state where hello hasn't been updated yet.
