### PR TITLE
Sub-modules now get their own guid

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -250,7 +250,8 @@
         // Stapes objects have some extra properties that are set on creation
         createModule : function( context ) {
             var instance = util.create( context );
-
+            
+            instance._guid = null;
             _.addGuid( instance, true );
 
             // Mixin events


### PR DESCRIPTION
Proposed fix for:
https://github.com/hay/stapes/issues/8
