### PR TITLE
Fix for IE8 error in removeHandler method

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -279,6 +279,7 @@
             if (type && handler) {
                 // Remove a specific handler
                 handlers = handlers[type];
+		if (!handlers) return;
                 for (var i = 0, l = handlers.length, h; i < l; i++) {
                     h = handlers[i].handler;
                     if (h && h === handler) {


### PR DESCRIPTION
IE 8 gets error "handlers is null or not an object" because changing index doesn't apply to the for loop index in each() method. Get index overflow.
