### PR TITLE
Avoid SyntaxError in example code

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,12 +438,12 @@
             <h2>module.off(eventType)</h2>
             <h2>module.off()</h2>
 
-            <p>Removes eventhandlers from an object. Giving in both an eventType
+            <p>Removes event handlers from an object. Giving both an eventType
                 and a handler will remove that specific handler from a module.
-                Giving only an eventType will remove all handlers binded to
+                Giving only an eventType will remove all handlers bound to
                 that event type.</p>
 
-            <p>With no arguments at all <code>off()</code>
+            <p>With no arguments at all, <code>off()</code>
                 will remove <i>all</i> event handlers from a module.</p>
 
             <pre><code>


### PR DESCRIPTION
Changed (var) to (val) so it does not throw 
SyntaxError: Unexpected token var
