### PR TITLE
undefined _guid error when using module.on in subclasses 

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -131,7 +131,7 @@
                     throw new Error("Please use 'new' when initializing Stapes classes");
                 }
 
-                if (includeEvents) {
+                if (this.on) {
                     _.addGuid( this, true );
                 }
 


### PR DESCRIPTION
Added a monkey patch to fix error when using events in subclasses.

```
var Parent = Stapes.subclass({});
var Module = Parent.subclass({ "sleep" : function() { this.emit('sleeping', 'very deep'); } });
var module = new Module();
module.on('sleeping', function(how) { console.log("i'm sleeping " + how); });

TypeError: 'undefined' is not an object (evaluating 'this._.guid')
```

 when instantiating subclasses, the constructor relies on variable named includeEvents that is evaluated to false (due to clojure out of scope, I guess)  and therefore does not properly add a _guid, making the use of events to thrown an error. 

Cheers,
