### PR TITLE
Fix for problem with unbinding events inside cb

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -178,8 +178,9 @@
         emitEvents : function(type, data, explicitType, explicitGuid) {
             explicitType = explicitType || false;
             explicitGuid = explicitGuid || this._guid;
-
-            var handlers = _.eventHandlers[explicitGuid][type];
+    
+            // make a local copy of the array
+            var handlers = Array.prototype.concat.apply(_.eventHandlers[explicitGuid][type]);
 
             for (var i = 0, l = handlers.length; i < l; i++) {
                 // Clone the event to prevent issue #19


### PR DESCRIPTION
When doing something like this:
.on('evt', function theCallback(data){
    this.off('evt', theCallback);
});

stapes will throw an error because the event handler array 
is being modified as it is looping though.

This edit copies the array locally to fix this.
