### PR TITLE
fix typo on extend function

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -550,7 +550,7 @@
         },
 
         "extend" : function() {
-            return _.extendThis.apply(_.Moduel, arguments);
+            return _.extendThis.apply(_.Module, arguments);
         },
 
         "mixinEvents" : function(obj) {


### PR DESCRIPTION
So turns out I was checking out your library and found out this typo. 

I'm wondering why nothing that uses the lib broke on your end as a git blame shown this change dates to Jan 11, but you might need some tests around this feature.
