### PR TITLE
Pick for selecting part of object attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,6 +892,7 @@
             <h1>pick</h1>
 
             <h2>module.pick( key[, key...]);</h2>
+            <h2>module.pick( keys);</h2>
 
             <p>Returns selected attributes as an object. Handy for JSON
                 serializing and persistence layers.</p>

--- a/stapes.js
+++ b/stapes.js
@@ -475,9 +475,14 @@
 
         pick: function() {
             var result = {};
+            var args = slice.call(arguments);
 
-            for (var i = 0; i < arguments.length; i++) {
-              var key = arguments[i];
+            if (args.length == 1 && _.typeOf(args[0]) == 'array') {
+              args = args[0];
+            }
+
+            for (var i = 0; i < args.length; i++) {
+              var key = args[i];
               if (this.has(key)) {
                 result[key] = _.attr(this._guid)[key];
               }

--- a/test/test.js
+++ b/test/test.js
@@ -167,6 +167,7 @@ test("pick", function() {
 
     deepEqual(module.pick(), {});
     deepEqual(module.pick('key2', 'key4'), {'key2': 'value2', 'key4': 'value4'});
+    deepEqual(module.pick(['key2', 'key4']), {'key2': 'value2', 'key4': 'value4'});
 });
 
 module("iterators");


### PR DESCRIPTION
Hey Hay

I've been using Stapes as a view model layer for Rivets.js, and Backbone as persistence layer.

In the view model layer I have both data that is going to be persisted (form data) and transient view attributes (such as whether todo entry is editable or not).

I've been missing a function similar to .pick in Underscore and Backbone to select only persistable attributes. 

```
module.set({
  title: "Wash dishes",
  completed: true,
  editable: true
});

var persistableAttrs = module.pick('title', 'completed');
// { title: "Wash dishes", completed: true }
```

If you care to include this to Stapes, you'll find tests, documentation and implementation with this pull request.
