### PR TITLE
Updated URL in README to new github.io domain for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 
 Full documentation available here:
 
-[http://hay.github.com/stapes/](http://hay.github.com/stapes/)
+[http://hay.github.io/stapes/](http://hay.github.io/stapes/)


### PR DESCRIPTION
https://github.com/blog/1452-new-github-pages-domain-github-io

The URL in the project description, "a (really) tiny Javascript MVC microframework 
http://hay.github.com/stapes" should also be updated but that's something only a project admin can do.
