### PR TITLE
Fixed missing comma in subclass() docs example

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
 var Module = Stapes.subclass({
     constructor : function(name) {
         this.name = name;
-    }
+    },
 
     sayName : function() {
         console.log('My name is: ' + this.name);


### PR DESCRIPTION
Just a small docs fix
