### PR TITLE
Don't set null to oldValue if it is false or 0.

### DIFF
--- a/stapes.js
+++ b/stapes.js
@@ -326,7 +326,7 @@
             var mutateData = {
                 "key" : key,
                 "newValue" : value,
-                "oldValue" : oldValue || null
+                "oldValue" : (oldValue !== "undefined") ? oldValue : null
             };
 
             this.emit('mutate', mutateData);


### PR DESCRIPTION
If `oldValue` is false or 0, `oldValue` in the mutate event is set to null and we are losing the original value.
