### PR TITLE
Fixes #61 - subclass does not copy static methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 tmp
+node_modules
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+
+all:
+
+test:
+	node_modules/.bin/qunit-cli -c stapes.js test/test.js
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 Full documentation available here:
 
 [http://hay.github.io/stapes/](http://hay.github.io/stapes/)
+
+### Testing
+
+```
+npm install qunit-cli
+make test
+```

--- a/stapes.js
+++ b/stapes.js
@@ -153,6 +153,14 @@
             constructor.prototype = _.create(superclass);
             constructor.prototype.constructor = constructor;
 
+            // copy static methods
+            var exclude = ['extend', 'parent', 'proto', 'subclass'];
+            for (var key in props.superclass) {
+                if (exclude.indexOf(key) == -1) {
+                    constructor[key] = props.superclass[key];
+                }
+            }
+
             _.extend(constructor, {
                 extend : function() {
                     return _.extendThis.apply(this, arguments);

--- a/test/test.js
+++ b/test/test.js
@@ -32,20 +32,20 @@ test("subclassing", function() {
     var c = new ClassOnly();
     ok( !('get' in c), "No get in classOnly classes");
     ok( 'subclass' in ClassOnly, "subclass in classOnly classes");
-});
 
-test('extend', function() {
-    var Module = Stapes.subclass();
-    var module = new Module();
+    // ensure static methods are copied
+    var ClassA = Stapes.subclass();
+    ClassA.extend({a: 1});
+    
+    var ClassB = ClassA.subclass();
+    ClassB.extend({a: 2, b: 3});
 
-    module.extend({
-        'name' : 'foo',
-        'say' : function() {
-            ok(this.name === 'foo');
-        }
-    });
-
-    module.say();
+    var ClassC = ClassB.subclass();
+    ok(ClassA.a == 1);
+    ok(ClassB.a == 2);
+    ok(ClassB.b == 3);
+    ok(ClassC.a == 2);
+    ok(ClassC.b == 3);
 });
 
 test("change events", function() {


### PR DESCRIPTION
Fixes #61, subclassing will now copy any static methods added by `extend`. I've also added some helper commands which make local testing easier, and amended the unit tests accordingly.

I have not updated the .min.js file, as I'm not sure which minifier you preferred to use, or any optimisations that you may usually apply. Plus this would have to be regenerated at the point of merge anyway, for sanity etc.

From what I can tell, this PR does not cause any regressions, however I'm in the process of adding automated multiple platform testing, which I've raised in #62. I'd recommend not merging this PR until I've submitted the results of these tests (which will be in the next few hours)
